### PR TITLE
[docker-build-setup] init and test build setup

### DIFF
--- a/.github/workflows/test-docker-setup.yaml
+++ b/.github/workflows/test-docker-setup.yaml
@@ -1,0 +1,24 @@
+name: "Test docker-setup"
+
+on:
+  push:
+
+permissions:
+  contents: read
+  id-token: write #required for GCP Workload Identity federation which we use to login into Google Artifact Registry
+
+jobs:
+  run-docker-setup:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
+
+      - uses: ./docker-setup
+        with:
+          GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          GCP_SERVICE_ACCOUNT_EMAIL: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
+          GCP_DOCKER_ARTIFACT_REPO: ${{ secrets.GCP_DOCKER_ARTIFACT_REPO }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DOCKER_ARTIFACT_REPO: ${{ secrets.AWS_DOCKER_ARTIFACT_REPO }}
+          GIT_CREDENTIALS: ${{ secrets.GIT_CREDENTIALS }}

--- a/docker-setup/README.md
+++ b/docker-setup/README.md
@@ -1,0 +1,6 @@
+# Docker Build Setup
+
+This is an opinionated and unified docker build setup action. It does the following:
+* Logs in to docker image registries (AWS ECR and GCP GAR)
+* Setup for buildx and other dependencies (crane)
+* Sets git credentials for private builds

--- a/docker-setup/action.yml
+++ b/docker-setup/action.yml
@@ -1,0 +1,71 @@
+name: 'Docker build setup'
+description: 'Docker build setup'
+inputs:
+  # GCP auth
+  GCP_WORKLOAD_IDENTITY_PROVIDER:
+    required: true
+  GCP_SERVICE_ACCOUNT_EMAIL:
+    required: true
+  GCP_DOCKER_ARTIFACT_REPO:
+    required: true
+    description: "GCP GAR repo to authenticate to"
+  # AWS auth
+  AWS_ACCESS_KEY_ID:
+    required: true
+  AWS_SECRET_ACCESS_KEY:
+    required: true
+  AWS_DOCKER_ARTIFACT_REPO:
+    required: true
+    description: "AWS ECR repo to authenticate to"
+  # Optional git credentials to use during the build process
+  # Useful if you need to pull private repos for depdenencies
+  GIT_CREDENTIALS:
+    description: "Optional credentials to pass to git"
+    required: false
+  
+runs:
+  using: "composite"
+  steps:
+    - id: auth
+      name: "Authenticate to Google Cloud"
+      uses: "google-github-actions/auth@dac4e13deb3640f22e3ffe758fd3f95e6e89f712" # pin@v0
+      with:
+        create_credentials_file: false
+        token_format: "access_token"
+        access_token_lifetime: 5400 # setting this to 1.5h since sometimes docker builds (special performance builds etc.) take that long. Default is 1h.
+        workload_identity_provider: ${{ inputs.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+        service_account: ${{ inputs.GCP_SERVICE_ACCOUNT_EMAIL }}
+
+    - name: Login to Google Artifact Registry
+      uses: docker/login-action@49ed152c8eca782a232dede0303416e8f356c37b # pin@v2
+      with:
+        registry: us-west1-docker.pkg.dev
+        username: oauth2accesstoken
+        password: ${{ steps.auth.outputs.access_token }}
+
+    - name: Login to ECR
+      uses: docker/login-action@49ed152c8eca782a232dede0303416e8f356c37b # pin@v2
+      with:
+        registry: ${{ inputs.AWS_DOCKER_ARTIFACT_REPO }}
+        username: ${{ inputs.AWS_ACCESS_KEY_ID }}
+        password: ${{ inputs.AWS_SECRET_ACCESS_KEY }}
+
+    - name: setup docker context for buildx
+      id: buildx-context
+      shell: bash
+      run: docker context create builders
+
+    - name: setup docker buildx
+      uses: docker/setup-buildx-action@15c905b16b06416d2086efa066dd8e3a35cc7f98 # pin v2.4.0
+      with:
+        endpoint: builders
+        version: v0.10.1
+
+    - uses: imjasonh/setup-crane@5146f708a817ea23476677995bf2133943b9be0b # pin@v0.1
+
+    - name: Setup git credentials
+      if: inputs.GIT_CREDENTIALS != ''
+      shell: bash
+      run: |
+        git config --global credential.helper store
+        echo "${{ inputs.GIT_CREDENTIALS }}" > ~/.git-credentials


### PR DESCRIPTION
Set up composite action that can be used in all supported repos that will:
* set up buildx runner
* set up auth against ECR and GAR
* inject git credentials if provided

This is the first step in separating out more of our CI into a separate repo for better versioning support