### PR TITLE
[rust-setup] init rust general setup

### DIFF
--- a/.github/workflows/test-docker-setup.yaml
+++ b/.github/workflows/test-docker-setup.yaml
@@ -1,0 +1,24 @@
+name: "Test docker-setup"
+
+on:
+  push:
+
+permissions:
+  contents: read
+  id-token: write #required for GCP Workload Identity federation which we use to login into Google Artifact Registry
+
+jobs:
+  run-docker-setup:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
+
+      - uses: ./docker-setup
+        with:
+          GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          GCP_SERVICE_ACCOUNT_EMAIL: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
+          GCP_DOCKER_ARTIFACT_REPO: ${{ secrets.GCP_DOCKER_ARTIFACT_REPO }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DOCKER_ARTIFACT_REPO: ${{ secrets.AWS_DOCKER_ARTIFACT_REPO }}
+          GIT_CREDENTIALS: ${{ secrets.GIT_CREDENTIALS }}

--- a/.github/workflows/test-docker-setup.yaml
+++ b/.github/workflows/test-docker-setup.yaml
@@ -12,8 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
+        with:
+          path: actions
 
-      - uses: ./docker-setup
+      - uses: ./actions/docker-setup
         with:
           GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           GCP_SERVICE_ACCOUNT_EMAIL: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}

--- a/.github/workflows/test-rust-setup.yaml
+++ b/.github/workflows/test-rust-setup.yaml
@@ -1,0 +1,44 @@
+name: "Test rust-setup"
+
+on:
+  push:
+
+jobs:
+  run-rust-setup-default:
+    runs-on: high-perf-docker
+    steps:
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
+        with:
+          path: actions
+
+      - uses: ./actions/rust-setup
+        with:
+          GIT_CREDENTIALS: ${{ secrets.GIT_CREDENTIALS }}
+          CHECKOUT_REPOSITORY: aptos-labs/aptos-core
+
+      # Because we have to checkout the actions in the first step, and then check out a rust repo (aptos-core), the actions directory will get overwritten
+      # We need to check it out again for the Post Run actions/checkout to succeed
+      # This is a special case for tests written in this repo
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
+        with:
+          path: actions
+
+  run-rust-setup-aptos-core:
+    runs-on: high-perf-docker
+    steps:
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
+        with:
+          path: actions
+
+      - uses: ./actions/rust-setup
+        with:
+          GIT_CREDENTIALS: ${{ secrets.GIT_CREDENTIALS }}
+          CHECKOUT_REPOSITORY: aptos-labs/aptos-core
+          REPOSITORY_SPECIFIC_SETUP: scripts/dev_setup.sh -b -r
+
+      # Because we have to checkout the actions in the first step, and then check out a rust repo (aptos-core), the actions directory will get overwritten
+      # We need to check it out again for the Post Run actions/checkout to succeed
+      # This is a special case for tests written in this repo
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
+        with:
+          path: actions

--- a/.github/workflows/update-action-docs.yaml
+++ b/.github/workflows/update-action-docs.yaml
@@ -1,0 +1,32 @@
+name: "Update Github Action docs"
+
+on:
+  pull_request:
+
+permissions:
+  contents: write
+
+jobs:
+  update-action-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
+        with:
+          ref: ${{ github.head_ref || github.ref_name }} # the branch name
+
+      - name: Install action-docs
+        run: npm install -g action-docs@1.1.1
+
+      - name: Generate docs
+        shell: bash
+        run: ./update-action-docs.sh
+
+      - name: Push changes
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
+          git add .
+          git commit -m "Update Github Action docs"
+          git push

--- a/docker-setup/README.md
+++ b/docker-setup/README.md
@@ -1,0 +1,6 @@
+# Docker Build Setup
+
+This is an opinionated and unified docker build setup action. It does the following:
+* Logs in to docker image registries (AWS ECR and GCP GAR)
+* Setup for buildx and other dependencies (crane)
+* Sets git credentials for private builds

--- a/docker-setup/README.md
+++ b/docker-setup/README.md
@@ -1,6 +1,26 @@
-# Docker Build Setup
+## Description
 
-This is an opinionated and unified docker build setup action. It does the following:
+Runs an opinionated and unified docker build setup action. It does the following:
 * Logs in to docker image registries (AWS ECR and GCP GAR)
 * Setup for buildx and other dependencies (crane)
 * Sets git credentials for private builds
+
+
+## Inputs
+
+| parameter | description | required | default |
+| --- | --- | --- | --- |
+| GCP_WORKLOAD_IDENTITY_PROVIDER | GCP Workload Identity provider | `true` |  |
+| GCP_SERVICE_ACCOUNT_EMAIL | GCP service account email | `true` |  |
+| GCP_DOCKER_ARTIFACT_REPO | GCP GAR repo to authenticate to | `true` |  |
+| AWS_ACCESS_KEY_ID | AWS access key id | `true` |  |
+| AWS_SECRET_ACCESS_KEY | AWS secret access key | `true` |  |
+| AWS_DOCKER_ARTIFACT_REPO | AWS ECR repo to authenticate to | `true` |  |
+| GIT_CREDENTIALS | Optional credentials to pass to git. Useful if you need to pull private repos for dependencies | `false` |  |
+
+
+## Runs
+
+This action is a `composite` action.
+
+

--- a/docker-setup/action.yml
+++ b/docker-setup/action.yml
@@ -1,0 +1,71 @@
+name: 'Docker build setup'
+description: 'Docker build setup'
+inputs:
+  # GCP auth
+  GCP_WORKLOAD_IDENTITY_PROVIDER:
+    required: true
+  GCP_SERVICE_ACCOUNT_EMAIL:
+    required: true
+  GCP_DOCKER_ARTIFACT_REPO:
+    required: true
+    description: "GCP GAR repo to authenticate to"
+  # AWS auth
+  AWS_ACCESS_KEY_ID:
+    required: true
+  AWS_SECRET_ACCESS_KEY:
+    required: true
+  AWS_DOCKER_ARTIFACT_REPO:
+    required: true
+    description: "AWS ECR repo to authenticate to"
+  # Optional git credentials to use during the build process
+  # Useful if you need to pull private repos for depdenencies
+  GIT_CREDENTIALS:
+    description: "Optional credentials to pass to git"
+    required: false
+  
+runs:
+  using: "composite"
+  steps:
+    - id: auth
+      name: "Authenticate to Google Cloud"
+      uses: "google-github-actions/auth@dac4e13deb3640f22e3ffe758fd3f95e6e89f712" # pin@v0
+      with:
+        create_credentials_file: false
+        token_format: "access_token"
+        access_token_lifetime: 5400 # setting this to 1.5h since sometimes docker builds (special performance builds etc.) take that long. Default is 1h.
+        workload_identity_provider: ${{ inputs.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+        service_account: ${{ inputs.GCP_SERVICE_ACCOUNT_EMAIL }}
+
+    - name: Login to Google Artifact Registry
+      uses: docker/login-action@49ed152c8eca782a232dede0303416e8f356c37b # pin@v2
+      with:
+        registry: us-west1-docker.pkg.dev
+        username: oauth2accesstoken
+        password: ${{ steps.auth.outputs.access_token }}
+
+    - name: Login to ECR
+      uses: docker/login-action@49ed152c8eca782a232dede0303416e8f356c37b # pin@v2
+      with:
+        registry: ${{ inputs.AWS_DOCKER_ARTIFACT_REPO }}
+        username: ${{ inputs.AWS_ACCESS_KEY_ID }}
+        password: ${{ inputs.AWS_SECRET_ACCESS_KEY }}
+
+    - name: setup docker context for buildx
+      id: buildx-context
+      shell: bash
+      run: docker context create builders
+
+    - name: setup docker buildx
+      uses: docker/setup-buildx-action@15c905b16b06416d2086efa066dd8e3a35cc7f98 # pin v2.4.0
+      with:
+        endpoint: builders
+        version: v0.10.1
+
+    - uses: imjasonh/setup-crane@5146f708a817ea23476677995bf2133943b9be0b # pin@v0.1
+
+    - name: Setup git credentials
+      if: inputs.GIT_CREDENTIALS != ''
+      shell: bash
+      run: |
+        git config --global credential.helper store
+        echo "${{ inputs.GIT_CREDENTIALS }}" > ~/.git-credentials

--- a/docker-setup/action.yml
+++ b/docker-setup/action.yml
@@ -1,28 +1,34 @@
-name: 'Docker build setup'
-description: 'Docker build setup'
+name: "Docker build setup"
+description: |
+  Runs an opinionated and unified docker build setup action. It does the following:
+  * Logs in to docker image registries (AWS ECR and GCP GAR)
+  * Setup for buildx and other dependencies (crane)
+  * Sets git credentials for private builds
 inputs:
   # GCP auth
   GCP_WORKLOAD_IDENTITY_PROVIDER:
     required: true
+    description: "GCP Workload Identity provider"
   GCP_SERVICE_ACCOUNT_EMAIL:
     required: true
+    description: "GCP service account email"
   GCP_DOCKER_ARTIFACT_REPO:
     required: true
     description: "GCP GAR repo to authenticate to"
   # AWS auth
   AWS_ACCESS_KEY_ID:
     required: true
+    description: "AWS access key id"
   AWS_SECRET_ACCESS_KEY:
     required: true
+    description: "AWS secret access key"
   AWS_DOCKER_ARTIFACT_REPO:
     required: true
     description: "AWS ECR repo to authenticate to"
-  # Optional git credentials to use during the build process
-  # Useful if you need to pull private repos for depdenencies
   GIT_CREDENTIALS:
-    description: "Optional credentials to pass to git"
+    description: "Optional credentials to pass to git. Useful if you need to pull private repos for dependencies"
     required: false
-  
+
 runs:
   using: "composite"
   steps:

--- a/rust-setup/README.md
+++ b/rust-setup/README.md
@@ -1,5 +1,21 @@
-# Rust Setup
+## Description
 
-This action checks out the given repo at a certain ref, and runs a standardized rust setup. It also has the option to provide shell commands for `REPOSITORY_SPECIFIC_SETUP`.
+Runs an opionated rust setup after optionally checking out a repository
 
-The repo has to be checked out to identify the rust toolchain to use.
+
+## Inputs
+
+| parameter | description | required | default |
+| --- | --- | --- | --- |
+| CHECKOUT_GIT_REF | Optional git ref to checkout | `false` |  |
+| CHECKOUT_REPOSITORY | Optional repository to checkout. If this repository has a rust-toolchain file, it will be used to override the default toolchain | `false` |  |
+| CHECKOUT_FETCH_DEPTH | Optional depth to checkout repository to | `false` |  |
+| REPOSITORY_SPECIFIC_SETUP | Optional repository specific dependencies to install | `false` |  |
+| GIT_CREDENTIALS | Optional credentials to pass to git. Useful if you need to pull private repos for dependencies | `false` |  |
+
+
+## Runs
+
+This action is a `composite` action.
+
+

--- a/rust-setup/README.md
+++ b/rust-setup/README.md
@@ -1,0 +1,5 @@
+# Rust Setup
+
+This action checks out the given repo at a certain ref, and runs a standardized rust setup. It also has the option to provide shell commands for `REPOSITORY_SPECIFIC_SETUP`.
+
+The repo has to be checked out to identify the rust toolchain to use.

--- a/rust-setup/action.yml
+++ b/rust-setup/action.yml
@@ -1,0 +1,74 @@
+name: "Rust build setup"
+description: |
+  Runs an opionated rust setup after optionally checking out a repository
+inputs:
+  CHECKOUT_GIT_REF:
+    description: "Optional git ref to checkout"
+    required: false
+  CHECKOUT_REPOSITORY:
+    description: "Optional repository to checkout. If this repository has a rust-toolchain file, it will be used to override the default toolchain"
+    required: false
+  CHECKOUT_FETCH_DEPTH:
+    description: "Optional depth to checkout repository to"
+    required: false
+  REPOSITORY_SPECIFIC_SETUP:
+    description: "Optional repository specific dependencies to install"
+    required: false
+  GIT_CREDENTIALS:
+    description: "Optional credentials to pass to git. Useful if you need to pull private repos for dependencies"
+    required: false
+
+runs:
+  using: composite
+  steps:
+    # Optionally check out a specific repo to get repo specific dependencies
+    - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
+      if: inputs.CHECKOUT_REPOSITORY != ''
+      with:
+        repository: ${{ inputs.CHECKOUT_REPOSITORY }}
+        ref: ${{ inputs.CHECKOUT_GIT_REF }}
+        fetch-depth: ${{ inputs.CHECKOUT_FETCH_DEPTH }}}
+        persist-credentials: false
+
+    - name: Install dependencies
+      run: sudo apt-get update && sudo apt-get install build-essential ca-certificates clang curl git libpq-dev libssl-dev pkg-config lsof lld --no-install-recommends --assume-yes
+      shell: bash
+
+    - name: Check for rust-toolchain existence
+      id: rust-toolchain-exists
+      uses: andstor/file-existence-action@20b4d2e596410855db8f9ca21e96fbe18e12930b # pin@v2
+      with:
+        files: "rust-toolchain"
+
+    - name: Install rust toolchain
+      id: toolchain
+      uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # pin@v1
+      with:
+        # if the rust-toolchain file exists, use it via override, otherwise use the default toolchain
+        override: steps.rust-toolchain-exists.outputs.files_exists
+        components: rustfmt, clippy
+
+    - name: Print results of rustup show
+      shell: bash
+      run: rustup show
+
+    # rust-cache action will cache ~/.cargo and ./target
+    # https://github.com/Swatinem/rust-cache#cache-details
+    - name: Run cargo cache
+      uses: Swatinem/rust-cache@359a70e43a0bb8a13953b04a90f76428b4959bb6 # pin@v2.2.0
+
+    - name: Run repository specific setup
+      if: inputs.REPOSITORY_SPECIFIC_SETUP != ''
+      shell: bash
+      run: exec bash -c "${{ inputs.REPOSITORY_SPECIFIC_SETUP }}"
+
+    - name: Add cargo bin to path
+      run: echo "/home/runner/.cargo/bin" | tee -a $GITHUB_PATH
+      shell: bash
+
+    - name: Setup git credentials
+      if: inputs.GIT_CREDENTIALS != ''
+      shell: bash
+      run: |
+        git config --global credential.helper store
+        echo "${{ inputs.GIT_CREDENTIALS }}" > ~/.git-credentials

--- a/update-action-docs.sh
+++ b/update-action-docs.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -e
+
+# This script updates the action docs in the README.md file for each action directory
+
+if command -v action-docs &> /dev/null
+then
+    echo "action-docs is installed"
+else
+    echo "action-docs could not be found. Please install action-docs:"
+    echo "$ npm install -g action-docs@1.1.1"
+    exit 1
+fi
+
+for action in $(find . -type f \( -name "action.yaml" -o -name "action.yml" \)); do
+    action_dir=$(dirname $action)
+    echo "Updating action in $action_dir"
+    action-docs --no-banner --action $action > $action_dir/README.md
+done


### PR DESCRIPTION
Stacked on #1 

Sets up rust setup action, as well as an extra utility that will help keep our actions documentation up to date `./update-action-docs.sh`

Runs an opinionated rust setup after optionally checking out a repository

Key notes:
* the repo MUST be checked out in the current working directory, to avoid checkouts overriding each other, and to ensure consistent known location of cargo cache items 
* you can specify `REPOSITORY_SPECIFIC_SETUP` to run shell commands (like invoking an install script from the checked-out repo) to complete the rust setup within the action itself.

