### PR TITLE
Add run-local-testnet action

### DIFF
--- a/.github/workflows/test-actions.yaml
+++ b/.github/workflows/test-actions.yaml
@@ -5,18 +5,20 @@ on:
 
 permissions:
   contents: read
-  id-token: write #required for GCP Workload Identity federation which we use to login into Google Artifact Registry
+  # Required for GCP Workload Identity federation which we use to login into Google Artifact Registry
+  id-token: write
 
 jobs:
   run-docker-setup:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./docker-setup
+
   run-gar-auth:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./gar-auth
         with:
           GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
@@ -28,3 +30,48 @@ jobs:
           GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           GCP_SERVICE_ACCOUNT_EMAIL: ${{ vars.GCP_SERVICE_ACCOUNT_EMAIL }}
           create_credentials_file: false
+
+  # Run a local testnet with the default arguments, which means it uses the latest
+  # released CLI. Confirm that the local testnet is actually up.
+  run-local-testnet-released:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ./run-local-testnet
+        with:
+          NODE_VERSION: 20
+      - run: curl --fail http://127.0.0.1:8080/v1
+      - run: curl --fail http://127.0.0.1:8081
+      - run: |
+          curl --fail http://127.0.0.1:8090/v1/graphql --data-raw '{"query":"{processor_status {last_success_version processor}}"}'
+
+  # Run a local testnet using a git ref.
+  run-local-testnet-git-ref:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./run-local-testnet
+        with:
+          NODE_VERSION: 20
+          CLI_GIT_REF: "nightly_36181e92c65020660a98d2041aadaafdc682cf8a"
+      - run: curl --fail http://127.0.0.1:8080/v1
+      - run: curl --fail http://127.0.0.1:8081
+      - run: |
+          curl --fail http://127.0.0.1:8090/v1/graphql --data-raw '{"query":"{processor_status {last_success_version processor}}"}'
+
+  # Run a local testnet without the indexer API. We confirm that curl exits with exit
+  # code 7, CURLE_COULDNT_CONNECT, which is what we expect since the indexer API should
+  # not be there.
+  run-local-testnet-no-indexer-api:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./run-local-testnet
+        with:
+          NODE_VERSION: 20
+          WITH_INDEXER_API: "false"
+      - run: curl --fail http://127.0.0.1:8080/v1
+      - run: curl --fail http://127.0.0.1:8081
+      - run: |
+          curl --fail http://127.0.0.1:8090/v1/graphql --data-raw '{"query":"{processor_status {last_success_version processor}}"}' || if [ $? -eq 7 ]; then exit 0; else exit 1; fi

--- a/run-local-testnet/README.md
+++ b/run-local-testnet/README.md
@@ -1,0 +1,21 @@
+## Description
+
+Use the Aptos CLI to run a local testnet. Once this action is succeeds, a local testnet will be running and ready to use.
+
+## Inputs
+
+| parameter | description | required | default |
+| --- | --- | --- | --- |
+| PNPM_VERSION | The version of pnpm to install. | `false` | 8.15.6 |
+| NODE_VERSION | The version of node to install. This must be specified if a .node-version file is not present. | `false` |  |
+| CLI_GIT_REF | The git ref (e.g. a tag, like 'testnet' or a commit SHA) of the Aptos CLI to use. If not given, we will use the latest released CLI. If given, the local testnet is run from a Docker image. | `false` |  |
+| DOCKER_ARTIFACT_REPO | The GCP Docker artifact repository + user. Only used if CLI_GIT_REF is set. | `false` | docker.io/aptoslabs |
+| WITH_INDEXER_API | If true, run an indexer API in addition to the node API and faucet. | `false` | true |
+| ADDITIONAL_ARGS | Additional arguments to pass to the CLI when running the local testnet. | `false` |  |
+
+
+## Runs
+
+This action is a `composite` action.
+
+

--- a/run-local-testnet/action.yaml
+++ b/run-local-testnet/action.yaml
@@ -1,0 +1,97 @@
+name: Run Local Testnet
+description: Use the Aptos CLI to run a local testnet. Once this action is succeeds, a local testnet will be running and ready to use.
+
+inputs:
+  PNPM_VERSION:
+    description: "The version of pnpm to install."
+    default: 8.15.6
+  NODE_VERSION:
+    description: "The version of node to install. This must be specified if a .node-version file is not present."
+    required: false
+  CLI_GIT_REF:
+    description: "The git ref (e.g. a tag, like 'testnet' or a commit SHA) of the Aptos CLI to use. If not given, we will use the latest released CLI. If given, the local testnet is run from a Docker image."
+    required: false
+  DOCKER_ARTIFACT_REPO:
+    description: "The GCP Docker artifact repository + user. Only used if CLI_GIT_REF is set."
+    default: "docker.io/aptoslabs"
+    required: false
+  WITH_INDEXER_API:
+    description: "If true, run an indexer API in addition to the node API and faucet."
+    default: "true"
+  ADDITIONAL_ARGS:
+    description: "Additional arguments to pass to the CLI when running the local testnet."
+    required: false
+
+runs:
+  using: composite
+  steps:
+    # Install node.
+    - uses: actions/setup-node@v4
+      with:
+        node-version: ${{ inputs.NODE_VERSION }}
+        node-version-file: .node-version
+        registry-url: "https://registry.npmjs.org"
+
+    # Install pnpm.
+    - uses: pnpm/action-setup@v2
+      with:
+        version: ${{ inputs.PNPM_VERSION }}
+
+    # Install wait-on.
+    - run: pnpm install -g wait-on
+      shell: bash
+
+    # Install the Aptos CLI.
+    - run: pnpm install -g @aptos-labs/aptos-cli
+      shell: bash
+      if: ${{ !inputs.CLI_GIT_REF }}
+
+    # If using the latest released CLI, print the version.
+    - run: aptos --version
+      shell: bash
+      if: ${{ !inputs.CLI_GIT_REF }}
+
+    # Run the local testnet using the latest released CLI if no git ref is given.
+    - run: |
+        aptos node run-local-testnet \
+        --assume-yes \
+        --force-restart \
+        ${{ inputs.WITH_INDEXER_API == 'true' && '--with-indexer-api' || ' ' }} \
+        ${{ inputs.ADDITIONAL_ARGS || ' ' }} \
+        --log-to-stdout >& ${{ runner.temp }}/local-testnet-logs.txt &
+      shell: bash
+      if: ${{ !inputs.CLI_GIT_REF }}
+
+    # Run the local testnet using an image if a git ref is given.
+    - run: |
+        docker run \
+        -v /var/run/docker.sock:/var/run/docker.sock \
+        --network host \
+        -v ${{ runner.temp }}/testnet:/testnet \
+        --name=local-testnet-${{ inputs.CLI_GIT_REF }} \
+        --detach \
+        ${{ inputs.DOCKER_ARTIFACT_REPO }}/tools:${{ inputs.CLI_GIT_REF }} \
+        aptos node run-local-testnet \
+        --test-dir /testnet \
+        ${{ inputs.WITH_INDEXER_API == 'true' && '--with-indexer-api' || ' ' }} \
+        ${{ inputs.ADDITIONAL_ARGS || ' ' }}
+      shell: bash
+      if: ${{ inputs.CLI_GIT_REF }}
+
+    # Wait for the local testnet to start up.
+    - run: wait-on --verbose --interval 1500 --timeout 120000 --httpTimeout 120000 http-get://127.0.0.1:8070
+      shell: bash
+
+    # Print the logs from the local testnet if the tests failed.
+    - name: Print local testnet logs if something failed
+      run: docker logs local-testnet-${{ inputs.IMAGE_TAG }}
+      shell: bash
+      if: ${{ inputs.CLI_GIT_REF && failure() }}
+
+    # Print the logs from the local testnet if the tests failed.
+    - name: Print local testnet logs if something failed
+      run: cat ${{ runner.temp }}/local-testnet-logs.txt
+      shell: bash
+      if: ${{ !inputs.CLI_GIT_REF && failure() }}
+
+


### PR DESCRIPTION
## Summary
We spin up a local testnet in at least 3 different places (aptos-core, aptos-ts-sdk, api-gateway). This PR adds an action we can use in all these places to avoid duplication.

See also https://github.com/aptos-labs/api-gateway/pull/117/files#r1554099979.

I'm a bit uncertain about whether to install node and pnpm in this action, it feels like something the user might already do / should do themselves. Curious for your thoughts @rustielin.

## Test Plan
See CI.

I use this successfully from https://github.com/aptos-labs/api-gateway/pull/117.