### PR TITLE
Print logs in post step for localnet action

### DIFF
--- a/run-local-testnet/action.yaml
+++ b/run-local-testnet/action.yaml
@@ -25,6 +25,21 @@ inputs:
 runs:
   using: composite
   steps:
+    # There is no way to configure post-if with this, so we just always print the logs
+    # in the post step.
+    - name: Set up printing logs in a post step
+      uses: aptos-labs/actions/with-post-step@main
+      with:
+        main: echo 'Configured post step to print logs at the end...'
+        post: |
+          echo "Printing logs from the localnet..."
+          if [ -n "${{ inputs.CLI_GIT_REF }}" ]; then
+            docker logs "local-testnet-${{ inputs.CLI_GIT_REF }}"
+          else
+            cat "${{ runner.temp }}/local-testnet-logs.txt"
+          fi
+          echo "Printed all logs from the localnet."
+
     # Install node.
     - uses: actions/setup-node@v4
       with:
@@ -81,17 +96,3 @@ runs:
     # Wait for the local testnet to start up.
     - run: wait-on --verbose --interval 1500 --timeout 120000 --httpTimeout 120000 http-get://127.0.0.1:8070
       shell: bash
-
-    # Print the logs from the local testnet if the tests failed.
-    - name: Print local testnet logs if something failed
-      run: docker logs local-testnet-${{ inputs.IMAGE_TAG }}
-      shell: bash
-      if: ${{ inputs.CLI_GIT_REF && failure() }}
-
-    # Print the logs from the local testnet if the tests failed.
-    - name: Print local testnet logs if something failed
-      run: cat ${{ runner.temp }}/local-testnet-logs.txt
-      shell: bash
-      if: ${{ !inputs.CLI_GIT_REF && failure() }}
-
-

--- a/with-post-step/README.md
+++ b/with-post-step/README.md
@@ -1,0 +1,23 @@
+## Description
+
+Generic JS Action to execute a main command and set a command as a post step.
+
+Learn more about why we need this here: https://github.com/actions/runner/issues/1478
+
+Originally forked from https://github.com/pyTooling/Actions/tree/main/with-post-step.
+
+
+## Inputs
+
+| parameter | description | required | default |
+| --- | --- | --- | --- |
+| main | Main command/script. | `true` |  |
+| post | Post command/script. | `true` |  |
+| key | Name of the state variable used to detect the post step. | `false` | POST |
+
+
+## Runs
+
+This action is a `node20` action.
+
+

--- a/with-post-step/action.yaml
+++ b/with-post-step/action.yaml
@@ -1,0 +1,54 @@
+# ==================================================================================================================== #
+# Authors:                                                                                                             #
+#   Patrick Lehmann                                                                                                    #
+#   Unai Martinez-Corral                                                                                               #
+#                                                                                                                      #
+# ==================================================================================================================== #
+# Copyright 2020-2024 The pyTooling Authors                                                                            #
+#                                                                                                                      #
+# Licensed under the Apache License, Version 2.0 (the "License");                                                      #
+# you may not use this file except in compliance with the License.                                                     #
+# You may obtain a copy of the License at                                                                              #
+#                                                                                                                      #
+#   http://www.apache.org/licenses/LICENSE-2.0                                                                         #
+#                                                                                                                      #
+# Unless required by applicable law or agreed to in writing, software                                                  #
+# distributed under the License is distributed on an "AS IS" BASIS,                                                    #
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.                                             #
+# See the License for the specific language governing permissions and                                                  #
+# limitations under the License.                                                                                       #
+#                                                                                                                      #
+# SPDX-License-Identifier: Apache-2.0                                                                                  #
+# ==================================================================================================================== #
+
+# Copied from: https://github.com/pyTooling/Actions/blob/main/with-post-step/action.yml
+
+# Unfortunately composite actions don't support running regular old commands as a post
+# step, so you need this hack. Learn more here:
+# https://dev.to/abiwinanda/github-action-adding-post-steps-in-composite-actions-5ak3
+
+name: With post step
+
+description: |
+  Generic JS Action to execute a main command and set a command as a post step.
+
+  Learn more about why we need this here: https://github.com/actions/runner/issues/1478
+
+  Originally forked from https://github.com/pyTooling/Actions/tree/main/with-post-step.
+
+inputs:
+  main:
+    description: "Main command/script."
+    required: true
+  post:
+    description: "Post command/script."
+    required: true
+  key:
+    description: "Name of the state variable used to detect the post step."
+    required: false
+    default: POST
+
+runs:
+  using: "node20"
+  main: "main.js"
+  post: "main.js"

--- a/with-post-step/main.js
+++ b/with-post-step/main.js
@@ -1,0 +1,52 @@
+/* ================================================================================================================== *
+ * Authors:                                                                                                           *
+ *   Unai Martinez-Corral                                                                                             *
+ *                                                                                                                    *
+ * ================================================================================================================== *
+ * Copyright 2021-2022 Unai Martinez-Corral <unai.martinezcorral@ehu.eus>                                             *
+ * Copyright 2022 Unai Martinez-Corral <umartinezcorral@antmicro.com>                                                 *
+ *                                                                                                                    *
+ * Licensed under the Apache License, Version 2.0 (the "License");                                                    *
+ * you may not use this file except in compliance with the License.                                                   *
+ * You may obtain a copy of the License at                                                                            *
+ *                                                                                                                    *
+ *     http://www.apache.org/licenses/LICENSE-2.0                                                                     *
+ *                                                                                                                    *
+ * Unless required by applicable law or agreed to in writing, software                                                *
+ * distributed under the License is distributed on an "AS IS" BASIS,                                                  *
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.                                           *
+ * See the License for the specific language governing permissions and                                                *
+ * limitations under the License.                                                                                     *
+ *                                                                                                                    *
+ * SPDX-License-Identifier: Apache-2.0                                                                                *
+ * ================================================================================================================== *
+ *                                                                                                                    *
+ * Context:                                                                                                           *
+ * * https://github.com/docker/login-action/issues/72                                                                 *
+ * * https://github.com/actions/runner/issues/1478                                                                    *
+ * ================================================================================================================== *
+ */
+
+// Copied from: https://github.com/pyTooling/Actions/blob/main/with-post-step/main.js
+
+// See action.yaml for an explanation for why we have this.
+
+const { spawn } = require("child_process");
+const { appendFileSync } = require("fs");
+const { EOL } = require("os");
+
+function run(cmd) {
+  const subprocess = spawn(cmd, { stdio: "inherit", shell: true });
+  subprocess.on("exit", (exitCode) => {
+    process.exitCode = exitCode;
+  });
+}
+
+const key = process.env.INPUT_KEY.toUpperCase();
+
+if ( process.env[`STATE_${key}`] !== undefined ) { // Are we in the 'post' step?
+  run(process.env.INPUT_POST);
+} else { // Otherwise, this is the main step
+  appendFileSync(process.env.GITHUB_STATE, `${key}=true${EOL}`);
+  run(process.env.INPUT_MAIN);
+}


### PR DESCRIPTION
As it is now you can't actually see the logs at the end because the logging steps run before the rest of the job. This way they run as a post step.

Unfortunately we need this post step hack. See https://github.com/actions/runner/issues/1478.