### PR TITLE
Add warning about Docker to run-local-testnet action

### DIFF
--- a/run-local-testnet/README.md
+++ b/run-local-testnet/README.md
@@ -1,6 +1,6 @@
 ## Description
 
-Use the Aptos CLI to run a local testnet. Once this action is succeeds, a local testnet will be running and ready to use.
+Use the Aptos CLI to run a local testnet. Once this action is succeeds, a local testnet will be running and ready to use. **Note**, if `WITH_INDEXER_API` is `true`, this action requires that the runner has Docker running and available. On some runners (e.g. macos-latest) Docker is not installed by default.
 
 ## Inputs
 

--- a/run-local-testnet/action.yaml
+++ b/run-local-testnet/action.yaml
@@ -1,5 +1,5 @@
 name: Run Local Testnet
-description: Use the Aptos CLI to run a local testnet. Once this action is succeeds, a local testnet will be running and ready to use.
+description: Use the Aptos CLI to run a local testnet. Once this action is succeeds, a local testnet will be running and ready to use. **Note**, if `WITH_INDEXER_API` is `true`, this action requires that the runner has Docker running and available. On some runners (e.g. macos-latest) Docker is not installed by default.
 
 inputs:
   PNPM_VERSION:


### PR DESCRIPTION
Someone got tripped up trying to run the run-local-testnet action on macos-latest. Here I add a warning explaining that you need Docker to be available.