### PR TITLE
Add actions to install CLI and run move tests

### DIFF
--- a/.github/workflows/move/.gitignore
+++ b/.github/workflows/move/.gitignore
@@ -1,0 +1,2 @@
+.aptos/
+build/

--- a/.github/workflows/move/Move.toml
+++ b/.github/workflows/move/Move.toml
@@ -1,0 +1,16 @@
+[package]
+name = "testing"
+version = "1.0.0"
+authors = []
+
+[addresses]
+addr = "_"
+
+[dev-addresses]
+
+[dependencies.AptosFramework]
+git = "https://github.com/aptos-labs/aptos-framework.git"
+rev = "mainnet"
+subdir = "aptos-framework"
+
+[dev-dependencies]

--- a/.github/workflows/move/sources/code.move
+++ b/.github/workflows/move/sources/code.move
@@ -1,0 +1,66 @@
+module addr::message {
+    use std::error;
+    use std::signer;
+    use std::string;
+    use aptos_framework::event;
+
+    struct MessageHolder has key {
+        message: string::String
+    }
+
+    #[event]
+    struct MessageChange has drop, store {
+        account: address,
+        from_message: string::String,
+        to_message: string::String
+    }
+
+    /// There is no message present
+    const ENO_MESSAGE: u64 = 0;
+
+    #[view]
+    public fun get_message(addr: address): string::String acquires MessageHolder {
+        assert!(
+            exists<MessageHolder>(addr),
+            error::not_found(ENO_MESSAGE)
+        );
+        borrow_global<MessageHolder>(addr).message
+    }
+
+    public entry fun set_message(account: signer, message: string::String) acquires MessageHolder {
+        let account_addr = signer::address_of(&account);
+        if (!exists<MessageHolder>(account_addr)) {
+            move_to(&account, MessageHolder { message })
+        } else {
+            let old_message_holder = borrow_global_mut<MessageHolder>(account_addr);
+            let from_message = old_message_holder.message;
+            event::emit(
+                MessageChange {
+                    account: account_addr,
+                    from_message,
+                    to_message: copy message
+                }
+            );
+            old_message_holder.message = message;
+        }
+    }
+
+    #[test_only]
+    use std::debug;
+
+    #[test(account = @0x1)]
+    public entry fun sender_can_set_message(account: signer) acquires MessageHolder {
+        let msg: string::String =
+            string::utf8(b"Running test for sender_can_set_message...");
+        debug::print(&msg);
+
+        let addr = signer::address_of(&account);
+        aptos_framework::account::create_account_for_test(addr);
+        set_message(account, string::utf8(b"Hello, Blockchain"));
+
+        assert!(
+            get_message(addr) == string::utf8(b"Hello, Blockchain"),
+            ENO_MESSAGE
+        );
+    }
+}

--- a/.github/workflows/test-actions.yaml
+++ b/.github/workflows/test-actions.yaml
@@ -75,3 +75,15 @@ jobs:
       - run: curl --fail http://127.0.0.1:8081
       - run: |
           curl --fail http://127.0.0.1:8090/v1/graphql --data-raw '{"query":"{processor_status {last_success_version processor}}"}' || if [ $? -eq 7 ]; then exit 0; else exit 1; fi
+
+  # This also transitively tests the install-aptos-cli action.
+  run-test-move:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./test-move
+        with:
+          WORKING_DIRECTORY: .github/workflows/move
+          ADDITIONAL_LINT_ARGS: "--named-addresses addr=0x5"
+          ADDITIONAL_COMPILE_ARGS: "--named-addresses addr=0x5"
+          ADDITIONAL_TEST_ARGS: "--named-addresses addr=0x5"

--- a/install-aptos-cli/README.md
+++ b/install-aptos-cli/README.md
@@ -1,0 +1,18 @@
+## Description
+
+Install the Aptos CLI. By default we use the latest released version of the Aptos CLI but you can specify the version. For now this only works on Linux runners.
+
+## Inputs
+
+| parameter | description | required | default |
+| --- | --- | --- | --- |
+| INSTALL_DIRECTORY | The directory to install the Aptos CLI. If not specified, it will be installed in /usr/local/bin | `false` | /usr/local/bin |
+| CLI_VERSION | The version of the Aptos CLI to install. If not specified, the latest version will be installed. | `false` |  |
+| SHELL | The shell to use for the steps. | `false` | bash |
+
+
+## Runs
+
+This action is a `composite` action.
+
+

--- a/install-aptos-cli/action.yaml
+++ b/install-aptos-cli/action.yaml
@@ -1,0 +1,31 @@
+name: Install Aptos CLI
+description: Install the Aptos CLI. By default we use the latest released version of the Aptos CLI but you can specify the version. For now this only works on Linux runners.
+
+inputs:
+  INSTALL_DIRECTORY:
+    description: "The directory to install the Aptos CLI. If not specified, it will be installed in /usr/local/bin"
+    required: false
+    default: "/usr/local/bin"
+  CLI_VERSION:
+    description: "The version of the Aptos CLI to install. If not specified, the latest version will be installed."
+    required: false
+  SHELL:
+    description: "The shell to use for the steps."
+    required: false
+    default: "bash"
+
+runs:
+  using: composite
+  steps:
+    - name: Fetch installation script
+      shell: ${{ inputs.SHELL }}
+      run: curl -fSL "https://aptos.dev/scripts/install_cli.py" -o ${{ runner.temp }}/install_cli.py
+
+    - name: Install Aptos CLI
+      shell: ${{ inputs.SHELL }}
+      run: |
+        if [ -n "${{ inputs.CLI_VERSION }}" ]; then
+          python3 ${{ runner.temp }}/install_cli.py -f -y --bin-dir ${{ inputs.INSTALL_DIRECTORY }} --cli-version ${{ inputs.CLI_VERSION }}
+        else
+          python3 ${{ runner.temp }}/install_cli.py -f -y --bin-dir ${{ inputs.INSTALL_DIRECTORY }}
+        fi

--- a/test-move/README.md
+++ b/test-move/README.md
@@ -1,0 +1,27 @@
+## Description
+
+Run move formatting checks, linting, compilation, and tests. You must checkout the code prior to using this. This uses the latest released version of the Aptos CLI.
+
+## Inputs
+
+| parameter | description | required | default |
+| --- | --- | --- | --- |
+| WORKING_DIRECTORY | The directory to run the commands from. | `false` | . |
+| SKIP_FMT | If true, skip formatting. | `false` | false |
+| SKIP_LINT | If true, skip linting. | `false` | false |
+| SKIP_COMPILE | If true, skip compilation. | `false` | false |
+| SKIP_TEST | If true, skip tests. | `false` | false |
+| ADDITIONAL_FMT_ARGS | Additional arguments to pass to the CLI when running movefmt. | `false` |  |
+| ADDITIONAL_LINT_ARGS | Additional arguments to pass to the CLI when running move lint. | `false` |  |
+| ADDITIONAL_COMPILE_ARGS | Additional arguments to pass to the CLI when running move compile. | `false` |  |
+| ADDITIONAL_TEST_ARGS | Additional arguments to pass to the CLI when running move test. | `false` |  |
+| CLI_VERSION | The version of the Aptos CLI to install. If not specified, the latest version will be installed. | `false` |  |
+| SKIP_INSTALLING_CLI | If true, skip installing the Aptos CLI. We will assume it is already on the PATH. | `false` | false |
+| SHELL | The shell to use for the steps. | `false` | bash |
+
+
+## Runs
+
+This action is a `composite` action.
+
+

--- a/test-move/action.yaml
+++ b/test-move/action.yaml
@@ -1,0 +1,95 @@
+name: Move Tests
+description: Run move formatting checks, linting, compilation, and tests. You must checkout the code prior to using this. This uses the latest released version of the Aptos CLI.
+
+inputs:
+  WORKING_DIRECTORY:
+    description: "The directory to run the commands from."
+    required: false
+    default: "."
+  SKIP_FMT:
+    description: "If true, skip formatting."
+    required: false
+    default: "false"
+  SKIP_LINT:
+    description: "If true, skip linting."
+    required: false
+    default: "false"
+  SKIP_COMPILE:
+    description: "If true, skip compilation."
+    required: false
+    default: "false"
+  SKIP_TEST:
+    description: "If true, skip tests."
+    required: false
+    default: "false"
+  ADDITIONAL_FMT_ARGS:
+    description: "Additional arguments to pass to the CLI when running movefmt."
+    required: false
+  ADDITIONAL_LINT_ARGS:
+    description: "Additional arguments to pass to the CLI when running move lint."
+    required: false
+  ADDITIONAL_COMPILE_ARGS:
+    description: "Additional arguments to pass to the CLI when running move compile."
+    required: false
+  ADDITIONAL_TEST_ARGS:
+    description: "Additional arguments to pass to the CLI when running move test."
+    required: false
+  CLI_VERSION:
+    description: "The version of the Aptos CLI to install. If not specified, the latest version will be installed."
+    required: false
+  SKIP_INSTALLING_CLI:
+    description: "If true, skip installing the Aptos CLI. We will assume it is already on the PATH."
+    required: false
+    default: "false"
+  SHELL:
+    description: "The shell to use for the steps."
+    required: false
+    default: "bash"
+
+runs:
+  using: composite
+  steps:
+    - name: Install Aptos CLI
+      uses: ./install-aptos-cli
+      if: ${{ inputs.SKIP_INSTALLING_CLI == 'false' }}
+      with:
+        CLI_VERSION: ${{ inputs.CLI_VERSION }}
+
+    - name: Install movefmt
+      shell: ${{ inputs.SHELL }}
+      working-directory: ${{ inputs.WORKING_DIRECTORY }}
+      run: aptos update movefmt
+
+    - name: Check for formatting changes
+      shell: ${{ inputs.SHELL }}
+      working-directory: ${{ inputs.WORKING_DIRECTORY }}
+      if: ${{ inputs.SKIP_FMT == 'false' }}
+      run: aptos move fmt ${{ inputs.ADDITIONAL_FMT_ARGS }}
+    - name: Return error if formatting changes detected
+      shell: ${{ inputs.SHELL }}
+      working-directory: ${{ inputs.WORKING_DIRECTORY }}
+      if: ${{ inputs.SKIP_FMT == 'false' }}
+      run: |
+        if git diff --name-only | grep "sources/" > /dev/null; then
+          echo "Error: Found unstaged changes in sources/ directory after formatting"
+          git diff
+          exit 1
+        fi
+
+    - name: Lint code
+      shell: ${{ inputs.SHELL }}
+      working-directory: ${{ inputs.WORKING_DIRECTORY }}
+      if: ${{ inputs.SKIP_LINT == 'false' }}
+      run: aptos move lint ${{ inputs.ADDITIONAL_LINT_ARGS }}
+
+    - name: Compile code
+      shell: ${{ inputs.SHELL }}
+      working-directory: ${{ inputs.WORKING_DIRECTORY }}
+      if: ${{ inputs.SKIP_COMPILE == 'false' }}
+      run: aptos move compile ${{ inputs.ADDITIONAL_COMPILE_ARGS }}
+
+    - name: Run move tests
+      shell: ${{ inputs.SHELL }}
+      working-directory: ${{ inputs.WORKING_DIRECTORY }}
+      if: ${{ inputs.SKIP_TEST == 'false' }}
+      run: aptos move test ${{ inputs.ADDITIONAL_TEST_ARGS }}


### PR DESCRIPTION
We do the same thing in lots of places and I'm sure the community does too. Providing an action they can use out of the box helps reduce effort and ensures people don't miss something.

See `.github/workflows/test-actions.yaml` for an example of how to use it.

I haven't tested installing a specific version yet, I need https://github.com/aptos-labs/developer-docs/pull/770 to land first.