### PR TITLE
Refer to install-aptos-cli in absolute terms in test-move action

### DIFF
--- a/test-move/action.yaml
+++ b/test-move/action.yaml
@@ -50,7 +50,7 @@ runs:
   using: composite
   steps:
     - name: Install Aptos CLI
-      uses: ./install-aptos-cli
+      uses: aptos-labs/actions/install-aptos-cli@main
       if: ${{ inputs.SKIP_INSTALLING_CLI == 'false' }}
       with:
         CLI_VERSION: ${{ inputs.CLI_VERSION }}


### PR DESCRIPTION
Otherwise you get errors like this:
```
Run aptos-labs/actions/test-move@main
Error: Can't find 'action.yml', 'action.yaml' or 'Dockerfile' under '/home/runner/_work/hong-bao/hong-bao/install-aptos-cli'. Did you forget to run actions/checkout before running your local action?
```