### PR TITLE
Add cross-platform install-aptos-cli and run-local-testnet-from-cli-release

### DIFF
--- a/.github/workflows/test-actions.yaml
+++ b/.github/workflows/test-actions.yaml
@@ -97,6 +97,57 @@ jobs:
       - run: |
           curl --fail http://127.0.0.1:8090/v1/graphql --data-raw '{"query":"{processor_status {last_success_version processor}}"}' || if [ $? -eq 7 ]; then exit 0; else exit 1; fi
 
+  # Test install-aptos-cli on Ubuntu.
+  run-install-aptos-cli-ubuntu:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./install-aptos-cli
+      - run: aptos --version
+
+  # Test install-aptos-cli on macOS.
+  run-install-aptos-cli-macos:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./install-aptos-cli
+      - run: aptos --version
+
+  # Test install-aptos-cli with a custom install directory.
+  run-install-aptos-cli-custom-dir:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./install-aptos-cli
+        with:
+          INSTALL_DIRECTORY: "/usr/local/bin"
+      - run: aptos --version
+      - run: which aptos | grep /usr/local/bin
+
+  # Test run-local-testnet-from-cli-release with default arguments (with indexer API).
+  run-local-testnet-from-cli-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./run-local-testnet-from-cli-release
+      - run: curl --fail http://127.0.0.1:8080/v1
+      - run: curl --fail http://127.0.0.1:8081
+      - run: |
+          curl --fail http://127.0.0.1:8090/v1/graphql --data-raw '{"query":"{processor_status {last_success_version processor}}"}'
+
+  # Test run-local-testnet-from-cli-release without the indexer API.
+  run-local-testnet-from-cli-release-no-indexer:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./run-local-testnet-from-cli-release
+        with:
+          WITH_INDEXER_API: "false"
+      - run: curl --fail http://127.0.0.1:8080/v1
+      - run: curl --fail http://127.0.0.1:8081
+      - run: |
+          curl --fail http://127.0.0.1:8090/v1/graphql --data-raw '{"query":"{processor_status {last_success_version processor}}"}' || if [ $? -eq 7 ]; then exit 0; else exit 1; fi
+
   # This also transitively tests the install-aptos-cli action.
   run-test-move:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-actions.yaml
+++ b/.github/workflows/test-actions.yaml
@@ -105,14 +105,6 @@ jobs:
       - uses: ./install-aptos-cli
       - run: aptos --version
 
-  # Test install-aptos-cli on macOS.
-  run-install-aptos-cli-macos:
-    runs-on: macos-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: ./install-aptos-cli
-      - run: aptos --version
-
   # Test install-aptos-cli with a custom install directory.
   run-install-aptos-cli-custom-dir:
     runs-on: ubuntu-latest

--- a/install-aptos-cli/README.md
+++ b/install-aptos-cli/README.md
@@ -1,30 +1,17 @@
 ## Description
 
-Install the Aptos CLI using the official install scripts from [aptos.dev](https://aptos.dev). Works on Linux, macOS, and Windows runners.
+Install the Aptos CLI using the official install scripts from aptos.dev. Works on Linux, macOS, and Windows runners.
 
 ## Inputs
 
-| Parameter | Description | Required | Default |
+| parameter | description | required | default |
 | --- | --- | --- | --- |
-| INSTALL_DIRECTORY | The directory to install the Aptos CLI. If not specified, the script default is used (`~/.local/bin` on Linux/macOS, `~\.aptoscli\bin` on Windows). | `false` | |
-| CLI_VERSION | The version of the Aptos CLI to install. If not specified, the latest version will be installed. | `false` | |
+| INSTALL_DIRECTORY | The directory to install the Aptos CLI. If not specified, the script default is used (~/.local/bin on Linux/macOS, ~\.aptoscli\bin on Windows). | `false` |  |
+| CLI_VERSION | The version of the Aptos CLI to install. If not specified, the latest version will be installed. | `false` |  |
 
-## Usage
-
-```yaml
-- uses: aptos-labs/actions/install-aptos-cli@main
-
-# With a specific version
-- uses: aptos-labs/actions/install-aptos-cli@main
-  with:
-    CLI_VERSION: "4.5.0"
-
-# With a custom install directory
-- uses: aptos-labs/actions/install-aptos-cli@main
-  with:
-    INSTALL_DIRECTORY: "/usr/local/bin"
-```
 
 ## Runs
 
 This action is a `composite` action.
+
+

--- a/install-aptos-cli/README.md
+++ b/install-aptos-cli/README.md
@@ -6,7 +6,7 @@ Install the Aptos CLI using the official install scripts from aptos.dev. Works o
 
 | parameter | description | required | default |
 | --- | --- | --- | --- |
-| INSTALL_DIRECTORY | The directory to install the Aptos CLI. If not specified, the script default is used (~/.local/bin on Linux/macOS, ~\.aptoscli\bin on Windows). | `false` |  |
+| INSTALL_DIRECTORY | The directory to install the Aptos CLI. If not specified, the script default is used (`~/.local/bin` on Linux/macOS, `~\.aptoscli\bin` on Windows). | `false` |  |
 | CLI_VERSION | The version of the Aptos CLI to install. If not specified, the latest version will be installed. | `false` |  |
 
 

--- a/install-aptos-cli/README.md
+++ b/install-aptos-cli/README.md
@@ -1,18 +1,30 @@
 ## Description
 
-Install the Aptos CLI. By default we use the latest released version of the Aptos CLI but you can specify the version. For now this only works on Linux runners.
+Install the Aptos CLI using the official install scripts from [aptos.dev](https://aptos.dev). Works on Linux, macOS, and Windows runners.
 
 ## Inputs
 
-| parameter | description | required | default |
+| Parameter | Description | Required | Default |
 | --- | --- | --- | --- |
-| INSTALL_DIRECTORY | The directory to install the Aptos CLI. If not specified, it will be installed in /usr/local/bin | `false` | /usr/local/bin |
-| CLI_VERSION | The version of the Aptos CLI to install. If not specified, the latest version will be installed. | `false` |  |
-| SHELL | The shell to use for the steps. | `false` | bash |
+| INSTALL_DIRECTORY | The directory to install the Aptos CLI. If not specified, the script default is used (`~/.local/bin` on Linux/macOS, `~\.aptoscli\bin` on Windows). | `false` | |
+| CLI_VERSION | The version of the Aptos CLI to install. If not specified, the latest version will be installed. | `false` | |
 
+## Usage
+
+```yaml
+- uses: aptos-labs/actions/install-aptos-cli@main
+
+# With a specific version
+- uses: aptos-labs/actions/install-aptos-cli@main
+  with:
+    CLI_VERSION: "4.5.0"
+
+# With a custom install directory
+- uses: aptos-labs/actions/install-aptos-cli@main
+  with:
+    INSTALL_DIRECTORY: "/usr/local/bin"
+```
 
 ## Runs
 
 This action is a `composite` action.
-
-

--- a/install-aptos-cli/README.md
+++ b/install-aptos-cli/README.md
@@ -6,7 +6,7 @@ Install the Aptos CLI using the official install scripts from aptos.dev. Works o
 
 | parameter | description | required | default |
 | --- | --- | --- | --- |
-| INSTALL_DIRECTORY | The directory to install the Aptos CLI. If not specified, the script default is used (`~/.local/bin` on Linux/macOS, `~\.aptoscli\bin` on Windows). | `false` |  |
+| INSTALL_DIRECTORY | The directory to install the Aptos CLI. If not specified, the script default is used (~/.local/bin on Linux/macOS, ~\.aptoscli\bin on Windows). | `false` |  |
 | CLI_VERSION | The version of the Aptos CLI to install. If not specified, the latest version will be installed. | `false` |  |
 
 

--- a/install-aptos-cli/action.yaml
+++ b/install-aptos-cli/action.yaml
@@ -1,31 +1,74 @@
 name: Install Aptos CLI
-description: Install the Aptos CLI. By default we use the latest released version of the Aptos CLI but you can specify the version. For now this only works on Linux runners.
+description: Install the Aptos CLI using the official install scripts from aptos.dev. Works on Linux, macOS, and Windows runners.
 
 inputs:
   INSTALL_DIRECTORY:
-    description: "The directory to install the Aptos CLI. If not specified, it will be installed in /usr/local/bin"
+    description: "The directory to install the Aptos CLI. If not specified, the script default is used (~/.local/bin on Linux/macOS, ~\\.aptoscli\\bin on Windows)."
     required: false
-    default: "/usr/local/bin"
   CLI_VERSION:
     description: "The version of the Aptos CLI to install. If not specified, the latest version will be installed."
     required: false
-  SHELL:
-    description: "The shell to use for the steps."
-    required: false
-    default: "bash"
 
 runs:
   using: composite
   steps:
-    - name: Fetch installation script
-      shell: ${{ inputs.SHELL }}
-      run: curl -fSL "https://aptos.dev/scripts/install_cli.py" -o ${{ runner.temp }}/install_cli.py
-
-    - name: Install Aptos CLI
-      shell: ${{ inputs.SHELL }}
+    - name: Install Aptos CLI (Linux/macOS)
+      if: runner.os != 'Windows'
+      shell: bash
       run: |
+        ARGS="-f -y"
         if [ -n "${{ inputs.CLI_VERSION }}" ]; then
-          python3 ${{ runner.temp }}/install_cli.py -f -y --bin-dir ${{ inputs.INSTALL_DIRECTORY }} --cli-version ${{ inputs.CLI_VERSION }}
-        else
-          python3 ${{ runner.temp }}/install_cli.py -f -y --bin-dir ${{ inputs.INSTALL_DIRECTORY }}
+          ARGS="$ARGS --cli-version ${{ inputs.CLI_VERSION }}"
         fi
+        if [ -n "${{ inputs.INSTALL_DIRECTORY }}" ]; then
+          ARGS="$ARGS --bin-dir ${{ inputs.INSTALL_DIRECTORY }}"
+        fi
+        curl -fsSL "https://aptos.dev/scripts/install_cli.sh" | sh -s -- $ARGS
+
+    - name: Install Aptos CLI (Windows)
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: |
+        $scriptContent = Invoke-WebRequest -Uri "https://aptos.dev/scripts/install_cli.ps1" -UseBasicParsing | Select-Object -ExpandProperty Content
+        $argList = @("-f", "-y")
+        if ("${{ inputs.CLI_VERSION }}" -ne "") {
+          $argList += "--cli-version"
+          $argList += "${{ inputs.CLI_VERSION }}"
+        }
+        if ("${{ inputs.INSTALL_DIRECTORY }}" -ne "") {
+          $argList += "--bin-dir"
+          $argList += "${{ inputs.INSTALL_DIRECTORY }}"
+        }
+        $tempScript = Join-Path $env:RUNNER_TEMP "install_cli.ps1"
+        Set-Content -Path $tempScript -Value $scriptContent
+        & $tempScript @argList
+
+    - name: Add install directory to PATH (Linux/macOS)
+      if: runner.os != 'Windows'
+      shell: bash
+      run: |
+        if [ -n "${{ inputs.INSTALL_DIRECTORY }}" ]; then
+          echo "${{ inputs.INSTALL_DIRECTORY }}" >> "$GITHUB_PATH"
+        else
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+        fi
+
+    - name: Add install directory to PATH (Windows)
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: |
+        if ("${{ inputs.INSTALL_DIRECTORY }}" -ne "") {
+          "${{ inputs.INSTALL_DIRECTORY }}" | Out-File -Append -FilePath $env:GITHUB_PATH
+        } else {
+          "$env:USERPROFILE\.aptoscli\bin" | Out-File -Append -FilePath $env:GITHUB_PATH
+        }
+
+    - name: Verify installation
+      shell: bash
+      if: runner.os != 'Windows'
+      run: aptos --version
+
+    - name: Verify installation (Windows)
+      shell: pwsh
+      if: runner.os == 'Windows'
+      run: aptos --version

--- a/install-aptos-cli/action.yaml
+++ b/install-aptos-cli/action.yaml
@@ -16,14 +16,14 @@ runs:
       if: runner.os != 'Windows'
       shell: bash
       run: |
-        ARGS="-f -y"
+        args=(-f -y)
         if [ -n "${{ inputs.CLI_VERSION }}" ]; then
-          ARGS="$ARGS --cli-version ${{ inputs.CLI_VERSION }}"
+          args+=(--cli-version "${{ inputs.CLI_VERSION }}")
         fi
         if [ -n "${{ inputs.INSTALL_DIRECTORY }}" ]; then
-          ARGS="$ARGS --bin-dir ${{ inputs.INSTALL_DIRECTORY }}"
+          args+=(--bin-dir "${{ inputs.INSTALL_DIRECTORY }}")
         fi
-        curl -fsSL "https://aptos.dev/scripts/install_cli.sh" | sh -s -- $ARGS
+        curl -fsSL "https://aptos.dev/scripts/install_cli.sh" | bash -s -- "${args[@]}"
 
     - name: Install Aptos CLI (Windows)
       if: runner.os == 'Windows'
@@ -58,9 +58,9 @@ runs:
       shell: pwsh
       run: |
         if ("${{ inputs.INSTALL_DIRECTORY }}" -ne "") {
-          "${{ inputs.INSTALL_DIRECTORY }}" | Out-File -Append -FilePath $env:GITHUB_PATH
+          Add-Content -Path $env:GITHUB_PATH -Value "${{ inputs.INSTALL_DIRECTORY }}"
         } else {
-          "$env:USERPROFILE\.aptoscli\bin" | Out-File -Append -FilePath $env:GITHUB_PATH
+          Add-Content -Path $env:GITHUB_PATH -Value "$env:USERPROFILE\.aptoscli\bin"
         }
 
     - name: Verify installation

--- a/run-local-testnet-from-cli-release/README.md
+++ b/run-local-testnet-from-cli-release/README.md
@@ -1,0 +1,48 @@
+## Description
+
+Install a released version of the Aptos CLI and start a local testnet. Once this action succeeds, a local testnet will be running and ready to use.
+
+**Note:** If `WITH_INDEXER_API` is `true` (the default), this action requires Docker to be running on the runner. Linux and macOS only.
+
+## Inputs
+
+| Parameter | Description | Required | Default |
+| --- | --- | --- | --- |
+| CLI_VERSION | The version of the Aptos CLI to install. If not specified, the latest version will be installed. | `false` | |
+| WITH_INDEXER_API | If true, run an indexer API in addition to the node API and faucet. Requires Docker. | `false` | `true` |
+| ADDITIONAL_ARGS | Additional arguments to pass to the CLI when running the local testnet. | `false` | |
+| WAIT_TIMEOUT | Health check timeout in seconds. | `false` | `120` |
+
+## Usage
+
+```yaml
+- uses: aptos-labs/actions/run-local-testnet-from-cli-release@main
+
+# Without the indexer API (no Docker required)
+- uses: aptos-labs/actions/run-local-testnet-from-cli-release@main
+  with:
+    WITH_INDEXER_API: "false"
+
+# With a specific CLI version and longer timeout
+- uses: aptos-labs/actions/run-local-testnet-from-cli-release@main
+  with:
+    CLI_VERSION: "4.5.0"
+    WAIT_TIMEOUT: "180"
+```
+
+## Default Ports
+
+Once the testnet is running, these endpoints are available:
+
+| Service | Port |
+| --- | --- |
+| Node API (REST) | 8080 |
+| Faucet | 8081 |
+| Indexer API (GraphQL) | 8090 |
+| Readiness endpoint | 8070 |
+| Transaction Stream (gRPC) | 50051 |
+| Postgres | 5433 |
+
+## Runs
+
+This action is a `composite` action.

--- a/run-local-testnet-from-cli-release/README.md
+++ b/run-local-testnet-from-cli-release/README.md
@@ -1,48 +1,19 @@
 ## Description
 
-Install a released version of the Aptos CLI and start a local testnet. Once this action succeeds, a local testnet will be running and ready to use.
-
-**Note:** If `WITH_INDEXER_API` is `true` (the default), this action requires Docker to be running on the runner. Linux and macOS only.
+Install a released version of the Aptos CLI and start a local testnet. Once this action succeeds, a local testnet will be running and ready to use. Requires Docker if WITH_INDEXER_API is true. Linux and macOS only.
 
 ## Inputs
 
-| Parameter | Description | Required | Default |
+| parameter | description | required | default |
 | --- | --- | --- | --- |
-| CLI_VERSION | The version of the Aptos CLI to install. If not specified, the latest version will be installed. | `false` | |
-| WITH_INDEXER_API | If true, run an indexer API in addition to the node API and faucet. Requires Docker. | `false` | `true` |
-| ADDITIONAL_ARGS | Additional arguments to pass to the CLI when running the local testnet. | `false` | |
-| WAIT_TIMEOUT | Health check timeout in seconds. | `false` | `120` |
+| CLI_VERSION | The version of the Aptos CLI to install. If not specified, the latest version will be installed. | `false` |  |
+| WITH_INDEXER_API | If true, run an indexer API in addition to the node API and faucet. Requires Docker. | `false` | true |
+| ADDITIONAL_ARGS | Additional arguments to pass to the CLI when running the local testnet. | `false` |  |
+| WAIT_TIMEOUT | Health check timeout in seconds. | `false` | 120 |
 
-## Usage
-
-```yaml
-- uses: aptos-labs/actions/run-local-testnet-from-cli-release@main
-
-# Without the indexer API (no Docker required)
-- uses: aptos-labs/actions/run-local-testnet-from-cli-release@main
-  with:
-    WITH_INDEXER_API: "false"
-
-# With a specific CLI version and longer timeout
-- uses: aptos-labs/actions/run-local-testnet-from-cli-release@main
-  with:
-    CLI_VERSION: "4.5.0"
-    WAIT_TIMEOUT: "180"
-```
-
-## Default Ports
-
-Once the testnet is running, these endpoints are available:
-
-| Service | Port |
-| --- | --- |
-| Node API (REST) | 8080 |
-| Faucet | 8081 |
-| Indexer API (GraphQL) | 8090 |
-| Readiness endpoint | 8070 |
-| Transaction Stream (gRPC) | 50051 |
-| Postgres | 5433 |
 
 ## Runs
 
 This action is a `composite` action.
+
+

--- a/run-local-testnet-from-cli-release/action.yaml
+++ b/run-local-testnet-from-cli-release/action.yaml
@@ -1,0 +1,62 @@
+name: Run Local Testnet from CLI Release
+description: Install a released version of the Aptos CLI and start a local testnet. Once this action succeeds, a local testnet will be running and ready to use. Requires Docker if WITH_INDEXER_API is true. Linux and macOS only.
+
+inputs:
+  CLI_VERSION:
+    description: "The version of the Aptos CLI to install. If not specified, the latest version will be installed."
+    required: false
+  WITH_INDEXER_API:
+    description: "If true, run an indexer API in addition to the node API and faucet. Requires Docker."
+    default: "true"
+  ADDITIONAL_ARGS:
+    description: "Additional arguments to pass to the CLI when running the local testnet."
+    required: false
+  WAIT_TIMEOUT:
+    description: "Health check timeout in seconds."
+    default: "120"
+
+runs:
+  using: composite
+  steps:
+    - name: Set up printing logs in a post step
+      uses: aptos-labs/actions/with-post-step@main
+      with:
+        main: echo "Configured post step to print localnet logs at the end..."
+        post: |
+          echo "Printing logs from the localnet..."
+          cat "${{ runner.temp }}/local-testnet-logs.txt" || echo "No log file found."
+          echo "Printed all logs from the localnet."
+
+    - name: Install Aptos CLI
+      uses: aptos-labs/actions/install-aptos-cli@main
+      with:
+        CLI_VERSION: ${{ inputs.CLI_VERSION }}
+
+    - name: Start local testnet
+      shell: bash
+      run: |
+        aptos node run-local-testnet \
+          --assume-yes \
+          --force-restart \
+          ${{ inputs.WITH_INDEXER_API == 'true' && '--with-indexer-api' || '' }} \
+          ${{ inputs.ADDITIONAL_ARGS || '' }} \
+          --log-to-stdout >& "${{ runner.temp }}/local-testnet-logs.txt" &
+
+    - name: Wait for local testnet to be ready
+      shell: bash
+      run: |
+        echo "Waiting for local testnet to be ready (timeout: ${{ inputs.WAIT_TIMEOUT }}s)..."
+        END_TIME=$(( $(date +%s) + ${{ inputs.WAIT_TIMEOUT }} ))
+        while true; do
+          if curl --fail --silent --output /dev/null http://127.0.0.1:8070; then
+            echo "Local testnet is ready!"
+            break
+          fi
+          if [ "$(date +%s)" -ge "$END_TIME" ]; then
+            echo "Timed out waiting for local testnet to be ready."
+            echo "Last 50 lines of logs:"
+            tail -50 "${{ runner.temp }}/local-testnet-logs.txt" || true
+            exit 1
+          fi
+          sleep 2
+        done


### PR DESCRIPTION
## Summary

- **`install-aptos-cli`**: Replaced the Linux-only Python-based installer with the official cross-platform scripts from aptos.dev. Now supports Linux, macOS, and Windows. Uses `install_cli.sh` (bash) and `install_cli.ps1` (PowerShell) with `--bin-dir` and `--cli-version` passthrough.
- **`run-local-testnet-from-cli-release`**: New action that installs a released CLI version and starts a local testnet. Uses a curl-based health check loop instead of Node/pnpm/`wait-on`. Prints localnet logs in a post step on failure.

### Breaking changes to `install-aptos-cli`
- Removed `SHELL` input (no longer needed — shell is selected based on runner OS)
- `INSTALL_DIRECTORY` default changed from `/usr/local/bin` to the script default (`~/.local/bin` on Linux/macOS)

## Test plan
- [ ] Test `install-aptos-cli` on `ubuntu-latest`
- [ ] Test `install-aptos-cli` on `macos-latest`
- [ ] Test `install-aptos-cli` with `CLI_VERSION` pinned
- [ ] Test `install-aptos-cli` with custom `INSTALL_DIRECTORY`
- [ ] Test `run-local-testnet-from-cli-release` on `ubuntu-latest` with Docker
- [ ] Test `run-local-testnet-from-cli-release` with `WITH_INDEXER_API: false`
- [ ] Verify `test-move` action still works (consumes `install-aptos-cli`)