### PR TITLE
ci: harden GitHub Actions workflows (zizmor audit)

### DIFF
--- a/.github/workflows/test-actions.yaml
+++ b/.github/workflows/test-actions.yaml
@@ -5,17 +5,19 @@ on:
 
 permissions:
   contents: read
-  # Required for GCP Workload Identity federation which we use to login into Google Artifact Registry
-  id-token: write
 
 jobs:
   run-akidosec-safe-chain:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
       - uses: aptos-labs/actions/akidosec-safe-chain@jkao97/akidosec-installation
       - name: Install Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
       - name: Validate safechain installation
         shell: bash
         run: |
@@ -32,14 +34,24 @@ jobs:
 
   run-docker-setup:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
       - uses: ./docker-setup
 
   run-gar-auth:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # Required for GCP Workload Identity federation which we use to login into Google Artifact Registry
+      id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
       - uses: ./gar-auth
         with:
           GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
@@ -56,8 +68,12 @@ jobs:
   # released CLI. Confirm that the local testnet is actually up.
   run-local-testnet-released:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - uses: ./run-local-testnet
         with:
@@ -70,8 +86,12 @@ jobs:
   # Run a local testnet using a git ref.
   run-local-testnet-git-ref:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
       - uses: ./run-local-testnet
         with:
           NODE_VERSION: 20
@@ -86,8 +106,12 @@ jobs:
   # not be there.
   run-local-testnet-no-indexer-api:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
       - uses: ./run-local-testnet
         with:
           NODE_VERSION: 20
@@ -100,16 +124,24 @@ jobs:
   # Test install-aptos-cli on Ubuntu.
   run-install-aptos-cli-ubuntu:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
       - uses: ./install-aptos-cli
       - run: aptos --version
 
   # Test install-aptos-cli with a custom install directory.
   run-install-aptos-cli-custom-dir:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
       - uses: ./install-aptos-cli
         with:
           INSTALL_DIRECTORY: "/usr/local/bin"
@@ -119,8 +151,12 @@ jobs:
   # Test run-local-testnet-from-cli-release with default arguments (with indexer API).
   run-local-testnet-from-cli-release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
       - uses: ./run-local-testnet-from-cli-release
       - run: curl --fail http://127.0.0.1:8080/v1
       - run: curl --fail http://127.0.0.1:8081
@@ -130,8 +166,12 @@ jobs:
   # Test run-local-testnet-from-cli-release without the indexer API.
   run-local-testnet-from-cli-release-no-indexer:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
       - uses: ./run-local-testnet-from-cli-release
         with:
           WITH_INDEXER_API: "false"
@@ -143,8 +183,12 @@ jobs:
   # This also transitively tests the install-aptos-cli action.
   run-test-move:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
       - uses: ./test-move
         with:
           WORKING_DIRECTORY: .github/workflows/move

--- a/.github/workflows/update-action-docs.yaml
+++ b/.github/workflows/update-action-docs.yaml
@@ -4,13 +4,15 @@ on:
   pull_request:
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   update-action-docs:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ github.head_ref || github.ref_name }} # the branch name
 


### PR DESCRIPTION
## Summary

This PR hardens the two GitHub Actions workflows in this repo against supply-chain and privilege-escalation risks, following the established pattern used across aptos-labs repos (aptos-cli, aptos-indexer-processors, aptos-ace, aptos-rust-sdk, aptos-sdk-specs).

### Findings addressed

| Finding | Count | Resolution |
|---------|-------|------------|
| `unpinned-uses` | 13 | Pinned all external action refs to immutable commit SHAs |
| `excessive-permissions` | 2 | Narrowed workflow-level permissions; scoped `id-token: write` and `contents: write` to only the jobs that need them |
| `artipacked` | 11 | Added `persist-credentials: false` to all checkout steps that do not push back to the repo |

**Before:** 43 findings (17 suppressed) — 14 high, 12 medium  
**After:** 2 findings — 1 high (intentional internal action), 1 medium (intentional credentials retention for push step)

### SHA resolutions

Tag immutability verified via `gh api repos/OWNER/REPO/rulesets` — both `actions/checkout` and `actions/setup-node` have only a branch-scoped "Copilot Code Review" ruleset with no `deletion` or `non_fast_forward` tag rules, confirming tags are mutable and must be replaced with SHAs.

| Action | Tag | Resolved SHA |
|--------|-----|-------------|
| `actions/checkout` | `v4` | `34e114876b0b11c390a56381ad16ebd13914f8d5` |
| `actions/setup-node` | `v4` | `49933ea5288caeca8642d1e84afbd3f7d6820020` |

### Intentional exceptions (not fixed)

1. **`aptos-labs/actions/akidosec-safe-chain@jkao97/akidosec-installation`** — Internal action under `aptos-labs/actions`. Per policy, internal actions must NOT be pinned to SHAs.
2. **`update-action-docs.yaml` checkout without `persist-credentials: false`** — This job runs `git push` to update docs on the PR branch. Credentials must be retained for the push to succeed.

### Changes

**`test-actions.yaml`**
- Removed `id-token: write` from workflow level; added only to `run-gar-auth` job (the only job that uses GCP Workload Identity)
- Added `permissions: contents: read` to all 10 jobs
- Pinned all 11 `actions/checkout@v4` to SHA
- Pinned `actions/setup-node@v4` to SHA
- Added `persist-credentials: false` to all 11 checkout steps

**`update-action-docs.yaml`**
- Moved workflow-level `permissions: contents: write` → `contents: read`; added `contents: write` at job level only
- Upgraded `actions/checkout` from v3 SHA (`93ea575`) to v4 SHA (`34e114876b0b11c390a56381ad16ebd13914f8d5`)

## Test plan

- [ ] Verify `run-gar-auth` job still authenticates to GCP (still has `id-token: write` at job level)
- [ ] Verify `update-action-docs` job still pushes doc updates (credentials retained)
- [ ] Verify all other test jobs pass (checkout, install, testnet runs, move tests)
- [ ] Run `zizmor .github/` locally to confirm only the two intentional exceptions remain